### PR TITLE
Add JSHint rule to forbid var statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
          "$": true,
          "dna": true,
          "window": true
-      }
+      },
+      "varstmt": true
    },
    "scripts": {
       "web-server": "lsof -P -i :3482 || http-server --port 3482 &",


### PR DESCRIPTION
Refers to #85 .
I changed some `const` to `var` temporarily to see if JSHint catches it on `npm test`. It did catch.
Please have a look.
Thanks!