### PR TITLE
Replace deprecated assert.deepEqual() in spec/dom.js

### DIFF
--- a/spec/dom.js
+++ b/spec/dom.js
@@ -3,7 +3,7 @@
 
 // Imports
 const fs =        require('fs');
-const assert =    require('assert').strict;
+const assert =    require('assert');
 const { JSDOM } = require('jsdom');
 
 // Setup
@@ -51,7 +51,7 @@ describe('Function dna.templateExists()', () => {
    it('identifies if a template is present before cloning', () => {
       const actual =   [dna.templateExists('book'), dna.templateExists('bogus')];
       const expected = [true, false];
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       });
 
    });
@@ -63,13 +63,13 @@ describe('Template cloning function dna.clone()', () => {
       dna.clone('book', bookCatalog[0]);
       const actual =   { title: $('.book h2').text() };
       const expected = { title: bookCatalog[0].title };
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       });
 
    it('creates a book with the correct author', () => {
       const actual =   { author: $('.book cite').text() };
       const expected = { author: bookCatalog[0].author };
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       });
 
    });
@@ -81,7 +81,7 @@ describe('Function dna.getModel()', () => {
       dna.clone('book', bookCatalog[1]);
       const actual =   { model: dna.getModel($('.book').last()) };
       const expected = { model: bookCatalog[1] };
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       });
 
    });
@@ -96,7 +96,7 @@ describe('Plugin call clone.dna("refresh")', () => {
       const titles =   $('.dna-clone.book').toArray().map(elem => $(elem).find('h2').text());
       const actual =   { titles: Array.from(titles) };
       const expected = { titles: ['The DOM 2.0!', 'Styling CSS3', 'Howdy HTML5'] };
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       });
 
    });
@@ -109,7 +109,7 @@ describe('Plugin call clone.dna("destroy")', () => {
       const titles =   $('.dna-clone.book').toArray().map(elem => $(elem).find('h2').text());
       const actual =   { titles: Array.from(titles) };
       const expected = { titles: ['The DOM 2.0!', 'Styling CSS3'] };
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       });
 
    });
@@ -120,7 +120,7 @@ describe('Function dna.templateExists()', () => {
    it('identifies if a template is present after cloning', () => {
       const actual =   [dna.templateExists('book'), dna.templateExists('bogus')];
       const expected = [true, false];
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       });
 
    });


### PR DESCRIPTION
### Issue
https://github.com/dnajs/dna.js/issues/94
### Test Result
![image](https://user-images.githubusercontent.com/20719656/95933614-36107c80-0df9-11eb-9779-b45d3d60a0a1.png)
![image](https://user-images.githubusercontent.com/20719656/95933631-3e68b780-0df9-11eb-9cd1-d5f499897d15.png)
![image](https://user-images.githubusercontent.com/20719656/95933636-432d6b80-0df9-11eb-8d38-96c26068eb36.png)
