### PR TITLE
Add JSHint rule to disallow invalid space characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
       "strict": "implied",
       "eqeqeq": true,
       "singleGroups": true,
+      "nonbsp": true,
       "undef": true,
       "unused": true,
       "varstmt": true,


### PR DESCRIPTION
https://github.com/dnajs/dna.js/issues/96
I've tried inserting the invalid one with option+command on mac.
![image](https://user-images.githubusercontent.com/20719656/95979642-2408fb00-0e46-11eb-8ff5-424a5d358942.png)
Here is the negative test (I didn't commit this) result which means it worked!